### PR TITLE
Change char* to const

### DIFF
--- a/linearalgebra/ilu0bicgstab/xilinx/src/sda_app/common/opencl_lib.cpp
+++ b/linearalgebra/ilu0bicgstab/xilinx/src/sda_app/common/opencl_lib.cpp
@@ -60,7 +60,7 @@ static size_t load_file_to_memory(const char *filename, unsigned char **result, 
 int setup_opencl(const char *target_device_name,
  cl_device_id *device_id, cl_context *context,
  cl_command_queue *commands, cl_program *program, cl_kernel *kernel,
- char *kernel_name, char *xclbin, bool *platform_awsf1) {
+ const char *kernel_name, const char *xclbin, bool *platform_awsf1) {
   int err;
   int status;
   char platform_vendor[1024];

--- a/linearalgebra/ilu0bicgstab/xilinx/src/sda_app/common/opencl_lib.hpp
+++ b/linearalgebra/ilu0bicgstab/xilinx/src/sda_app/common/opencl_lib.hpp
@@ -25,7 +25,7 @@
 int setup_opencl(const char *target_device_name,
  cl_device_id *device_id, cl_context *context,
  cl_command_queue *commands, cl_program *program, cl_kernel *kernel,
- char *kernel_name, char *xclbin, bool *platform_awsf1);
+ const char *kernel_name, const char *xclbin, bool *platform_awsf1);
 int swap_kernel(cl_device_id device_id, cl_context context, cl_program *program,
  cl_kernel *kernel, char *dummy_kernel_name, char *dummy_xclbin,
  char *main_kernel_name, char *main_xclbin);


### PR DESCRIPTION
I needed to make this change to compile https://github.com/OPM/opm-simulators/pull/3672 with FPGA support. Perhaps it's due to me using GCC 10 instead of 7.

@blattms I'm not sure who to ping here.